### PR TITLE
Enabled MongoDB to accept connection from any host

### DIFF
--- a/mongo/deployments/mongo.yaml
+++ b/mongo/deployments/mongo.yaml
@@ -14,7 +14,7 @@ spec:
       - image: mongo:latest
         imagePullPolicy: Always
         name: mongo
-        command: ["mongod", "--smallfiles"]
+        command: ["mongod", "--bind_ip_all", "--smallfiles"]
         ports:
         - containerPort: 27017
         volumeMounts:


### PR DESCRIPTION
Updated mongoDB command to include `--bind_ip_all`, which allows connections from any host. Without this, MongoDB will only allow connection from localhost, causing problems when the Tyk installation is spread across many hosts.